### PR TITLE
Fix/support multiline text

### DIFF
--- a/photomanipulator/build.gradle
+++ b/photomanipulator/build.gradle
@@ -8,7 +8,7 @@ android {
         minSdkVersion 16
         targetSdkVersion 29
         versionCode 1
-        versionName "1.0.5"
+        versionName "1.0.6"
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     }

--- a/photomanipulator/src/androidTest/java/com/guhungry/photomanipulator/BitmapUtilsAndroidTest.kt
+++ b/photomanipulator/src/androidTest/java/com/guhungry/photomanipulator/BitmapUtilsAndroidTest.kt
@@ -120,6 +120,20 @@ internal class BitmapUtilsAndroidTest {
         assertThat(background!!.getPixel(14, 0), equalTo(Color.GREEN))
     }
 
+    @Test
+    fun printText_when_multiline_should_text_correctly() {
+        val options = BitmapFactory.Options().apply {
+            inMutable = true
+            inTargetDensity = DisplayMetrics.DENSITY_DEFAULT
+            inPreferredColorSpace = ColorSpace.get(ColorSpace.Named.SRGB)
+        }
+        background = TestHelper.drawableBitmap(R.drawable.background, options)
+        BitmapUtils.printText(background!!, "My Text\nPrint", PointF(12f, 5f), Color.GREEN, 23f, Typeface.DEFAULT_BOLD, thickness = 5f)
+        BitmapUtils.printText(background!!, "My\nText\nPrint", PointF(200f, 5f), Color.YELLOW, 23f, Typeface.DEFAULT_BOLD, thickness = 1f, alignment = Paint.Align.CENTER)
+
+        assertThat(background!!.getPixel(14, 0), equalTo(Color.GREEN))
+    }
+
     /**
      * Fix Issue For
      * https://github.com/react-native-community/react-native-image-editor/issues/27

--- a/photomanipulator/src/main/java/com/guhungry/photomanipulator/BitmapUtils.kt
+++ b/photomanipulator/src/main/java/com/guhungry/photomanipulator/BitmapUtils.kt
@@ -153,7 +153,12 @@ object BitmapUtils {
                 strokeWidth = thickness
             }
         }
-        canvas.drawText(text, position.x, position.y + (size / 2), paint)
+
+        var offset = position.y + (size / 2);
+        text.split("\n").forEach {
+            canvas.drawText(it, position.x, offset, paint)
+            offset += paint.descent() - paint.ascent()
+        }
     }
 
     /**


### PR DESCRIPTION
Canvas's drawText() doesn't support new line character so for example "Hello,\nNew Line" will be drawn as "Hello,New Line".
So we need to handle new line by ourself.

With this PR should fixes issue for https://github.com/guhungry/react-native-photo-manipulator/issues/366