### PR TITLE
Fix error publish agp 8.3.1

### DIFF
--- a/gradle/publish-module.gradle
+++ b/gradle/publish-module.gradle
@@ -46,9 +46,6 @@ afterEvaluate {
                     artifact("$buildDir/libs/${project.getName()}-${version}.jar")
                 }
 
-                // artifact androidSourcesJar
-                // artifact javadocJar
-
                 pom {
                     packaging = 'aar'
                     name = libraryName

--- a/gradle/publish-module.gradle
+++ b/gradle/publish-module.gradle
@@ -36,6 +36,7 @@ afterEvaluate {
     publishing {
         publications {
             release(MavenPublication) {
+                tasks.named("generateMetadataFileForReleasePublication").configure { dependsOn("androidSourcesJar") }
                 groupId publishedGroupId
                 artifactId artifact
                 version libraryVersion
@@ -45,8 +46,8 @@ afterEvaluate {
                     artifact("$buildDir/libs/${project.getName()}-${version}.jar")
                 }
 
-                artifact androidSourcesJar
-                artifact javadocJar
+                // artifact androidSourcesJar
+                // artifact javadocJar
 
                 pom {
                     packaging = 'aar'

--- a/photomanipulator/build.gradle
+++ b/photomanipulator/build.gradle
@@ -14,6 +14,10 @@ android {
 
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
         consumerProguardFiles "consumer-rules.pro"
+
+        aarMetadata {
+            minCompileSdk = 16
+        }
     }
 
     buildTypes {
@@ -38,6 +42,12 @@ android {
             excludes += ['META-INF/LICENSE.md', 'META-INF/LICENSE-notice.md']
         }
     }
+    publishing {
+        singleVariant("release") {
+            withSourcesJar()
+            withJavadocJar()
+        }
+    }
     testOptions {
         animationsDisabled true
 
@@ -45,6 +55,9 @@ android {
             includeAndroidResources = true
             unitTests.returnDefaultValues = true
         }
+    }
+    testFixtures {
+        enable = true
     }
 }
 


### PR DESCRIPTION
Pipeline `Publish Maven Central` fail (https://github.com/guhungry/android-photo-manipulator/actions/runs/8454928685)

- Use Java 19 to Build
- Update publish config https://developer.android.com/build/publish-library