### PR TITLE
Feature : Rotate Image

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -14,7 +14,7 @@ on:
 jobs:
   publish:
     name: Build and Test
-    runs-on: macos-latest
+    runs-on: macos-13
 
     steps:
       - name: Checkout

--- a/README.md
+++ b/README.md
@@ -77,12 +77,20 @@ Overlay image on top of background image
 | position   | PointF                | Yes      | Position of overlay image in background image                          |
 
 ### BitmapUtils.flip()
-Overlay image on top of background image
+Flip the image horizontally, vertically or both
 
 | NAME       | TYPE                  | REQUIRED | DESCRIPTION                                                            |
 |------------|-----------------------|----------|------------------------------------------------------------------------|
 | image      | Bitmap                | Yes      | The image to be flipped                                                |
 | mode       | FlipMode              | Yes      | Flip mode .Horizontal, .Vertical or .Both                              |
+
+### BitmapUtils.rotate()
+Rotate the image 90°, 180° or 270°
+
+| NAME       | TYPE                  | REQUIRED | DESCRIPTION                                                            |
+|------------|-----------------------|----------|------------------------------------------------------------------------|
+| image      | Bitmap                | Yes      | The image to be rotated                                                |
+| mode       | RotationMode          | Yes      | Rotation mode .R90 (90° Clockwise), .R180 (180° Half Rotation) or .R270 (270° Clockwise, aka 90° Counterclockwise)                              |
 
 ### BitmapUtils.getCorrectOrientationMatrix()
 Get corrected transform matrix for orientation data in EXIF

--- a/build.gradle
+++ b/build.gradle
@@ -35,7 +35,7 @@ allprojects {
 }
 
 task clean(type: Delete) {
-    delete rootProject.buildDir
+    delete rootProject.layout.buildDirectory
 }
 
 def getExtOrDefault(name) {

--- a/photomanipulator/src/androidTest/java/com/guhungry/photomanipulator/BitmapUtilsAndroidTest.kt
+++ b/photomanipulator/src/androidTest/java/com/guhungry/photomanipulator/BitmapUtilsAndroidTest.kt
@@ -117,7 +117,7 @@ internal class BitmapUtilsAndroidTest {
         background = TestHelper.drawableBitmap(R.drawable.background, options)
         BitmapUtils.printText(background!!, "My Text Print", PointF(12f, 5f), Color.GREEN, 23f, Typeface.DEFAULT_BOLD, thickness = 1f)
 
-        assertThat(background!!.getPixel(14, 0), equalTo(Color.GREEN))
+        assertThat(background!!.getPixel(13, 2), equalTo(Color.GREEN))
     }
 
     @Test
@@ -187,6 +187,58 @@ internal class BitmapUtilsAndroidTest {
         val actual4 = BitmapUtils.flip(actual3, FlipMode.Horizontal)
 
         assertThat(actual4.getPixel(55, 67), equalTo(0xFF118BCE.toInt()))
+    }
+
+    @Test
+    fun rotate_when_R90_should_rotate_correctly() {
+        val options = BitmapFactory.Options().apply {
+            inMutable = true
+            inTargetDensity = DisplayMetrics.DENSITY_DEFAULT
+            inPreferredColorSpace = ColorSpace.get(ColorSpace.Named.SRGB)
+        }
+        background = TestHelper.drawableBitmap(R.drawable.background, options)
+        val actual = BitmapUtils.rotate(background!!, RotationMode.R90)
+
+        assertThat(actual.getPixel(55, 67), equalTo(0xFF072C60.toInt()))
+    }
+
+    @Test
+    fun rotate_when_R180_should_rotate_correctly() {
+        val options = BitmapFactory.Options().apply {
+            inMutable = true
+            inTargetDensity = DisplayMetrics.DENSITY_DEFAULT
+            inPreferredColorSpace = ColorSpace.get(ColorSpace.Named.SRGB)
+        }
+        background = TestHelper.drawableBitmap(R.drawable.background, options)
+        val actual = BitmapUtils.rotate(background!!, RotationMode.R180)
+
+        assertThat(actual.getPixel(55, 67), equalTo(0xFF010F29.toInt()))
+    }
+
+    @Test
+    fun rotate_when_R270_should_rotate_correctly() {
+        val options = BitmapFactory.Options().apply {
+            inMutable = true
+            inTargetDensity = DisplayMetrics.DENSITY_DEFAULT
+            inPreferredColorSpace = ColorSpace.get(ColorSpace.Named.SRGB)
+        }
+        background = TestHelper.drawableBitmap(R.drawable.background, options)
+        val actual = BitmapUtils.rotate(background!!, RotationMode.R270)
+
+        assertThat(actual.getPixel(55, 67), equalTo(0xFF0D5CA9.toInt()))
+    }
+
+    @Test
+    fun rotate_when_None_should_rotate_correctly() {
+        val options = BitmapFactory.Options().apply {
+            inMutable = true
+            inTargetDensity = DisplayMetrics.DENSITY_DEFAULT
+            inPreferredColorSpace = ColorSpace.get(ColorSpace.Named.SRGB)
+        }
+        background = TestHelper.drawableBitmap(R.drawable.background, options)
+        val actual = BitmapUtils.rotate(background!!, RotationMode.None)
+
+        assertThat(actual.getPixel(55, 67), equalTo(0xFF118BCE.toInt()))
     }
 
     /**

--- a/photomanipulator/src/main/java/com/guhungry/photomanipulator/BitmapUtils.kt
+++ b/photomanipulator/src/main/java/com/guhungry/photomanipulator/BitmapUtils.kt
@@ -200,8 +200,21 @@ object BitmapUtils {
     fun flip(image: Bitmap, mode: FlipMode): Bitmap {
         if (mode == FlipMode.None) return image
         val matrix = Matrix()
-        matrix.preScale(mode.scaleX, mode.scaleY);
-        return Bitmap.createBitmap(image, 0, 0, image.getWidth(), image.getHeight(), matrix, true);
+        matrix.preScale(mode.scaleX, mode.scaleY)
+        return Bitmap.createBitmap(image, 0, 0, image.getWidth(), image.getHeight(), matrix, true)
+    }
+
+    /**
+     * Rotate image 90, 180, 270 degrees
+     * @param image Image to be rotated
+     * @param mode Rotation Mode
+     */
+    @JvmStatic
+    fun rotate(image: Bitmap, mode: RotationMode): Bitmap {
+        if (mode == RotationMode.None) return image
+        val matrix = Matrix()
+        matrix.preRotate(mode.degrees)
+        return Bitmap.createBitmap(image, 0, 0, image.getWidth(), image.getHeight(), matrix, true)
     }
 
     fun getCorrectOrientationMatrix(input: InputStream): Matrix? {

--- a/photomanipulator/src/main/java/com/guhungry/photomanipulator/RotationMode.kt
+++ b/photomanipulator/src/main/java/com/guhungry/photomanipulator/RotationMode.kt
@@ -1,0 +1,8 @@
+package com.guhungry.photomanipulator
+
+enum class RotationMode(val degrees: Float) {
+    None(0f),
+    R90(90f),
+    R180(180f),
+    R270(270f)
+}

--- a/photomanipulator/src/test/java/com/guhungry/photomanipulator/BitmapUtilsTest.kt
+++ b/photomanipulator/src/test/java/com/guhungry/photomanipulator/BitmapUtilsTest.kt
@@ -108,6 +108,15 @@ internal class BitmapUtilsTest {
 
         val actual = BitmapUtils.flip(background, FlipMode.None)
 
-        assertThat(actual, sameInstance(background));
+        assertThat(actual, sameInstance(background))
+    }
+
+    @Test
+    fun `rotate when RotationMode None do nothing`() {
+        val background = mock(Bitmap::class.java)
+
+        val actual = BitmapUtils.rotate(background, RotationMode.None)
+
+        assertThat(actual, sameInstance(background))
     }
 }


### PR DESCRIPTION
Add support for rotate image 90°, 180° or 270°

| Rotation Mode      | Image      |
| ------------- | ------------- |
| Original | ![0-original](https://github.com/guhungry/android-photo-manipulator/assets/4032276/fe534b74-41df-40e3-b8b6-4f078edd45ad) |
| 90° Clockwise | ![1-90](https://github.com/guhungry/android-photo-manipulator/assets/4032276/047287e2-d02d-4f77-b232-7d910ecc28b4) |
| 180° or Half Rotation | ![2-180](https://github.com/guhungry/android-photo-manipulator/assets/4032276/c54e0072-15b8-45bd-862e-b6485490fa33) |
| 270° Clockwise or 90° Counterclockwise | ![3-270](https://github.com/guhungry/android-photo-manipulator/assets/4032276/c6ab0925-bdad-4c45-81a6-e441a6ff96a7) |