### PR TITLE
Feature : Print text with shadow

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -37,7 +37,7 @@ android {
         compose true
     }
     composeOptions {
-        kotlinCompilerExtensionVersion '1.5.1'
+        kotlinCompilerExtensionVersion '1.5.14'
     }
     packaging {
         resources {
@@ -49,7 +49,7 @@ android {
 dependencies {
 
     implementation 'androidx.core:core-ktx:1.13.1'
-    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.8.2'
+    implementation 'androidx.lifecycle:lifecycle-runtime-ktx:2.8.3'
     implementation 'androidx.activity:activity-compose:1.9.0'
     implementation platform('androidx.compose:compose-bom:2024.06.00')
     implementation 'androidx.compose.ui:ui'

--- a/app/src/main/java/com/guhungry/photomanipulator/demo/ImageUtils.kt
+++ b/app/src/main/java/com/guhungry/photomanipulator/demo/ImageUtils.kt
@@ -5,8 +5,8 @@ import android.graphics.Bitmap
 import android.graphics.BitmapFactory
 import android.net.Uri
 import com.guhungry.photomanipulator.BitmapUtils
-import com.guhungry.photomanipulator.CGRect
-import com.guhungry.photomanipulator.CGSize
+import com.guhungry.photomanipulator.model.CGRect
+import com.guhungry.photomanipulator.model.CGSize
 import com.guhungry.photomanipulator.FileUtils
 import java.io.InputStream
 import java.util.Locale

--- a/app/src/main/java/com/guhungry/photomanipulator/demo/MainActivity.kt
+++ b/app/src/main/java/com/guhungry/photomanipulator/demo/MainActivity.kt
@@ -15,6 +15,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import com.guhungry.photomanipulator.BitmapUtils
 import com.guhungry.photomanipulator.demo.ui.theme.MyApplicationTheme
+import com.guhungry.photomanipulator.model.TextStyle
 
 
 class MainActivity : ComponentActivity() {
@@ -42,7 +43,8 @@ class MainActivity : ComponentActivity() {
         val bee = ImageUtils.bitmapFromUri(
             this.applicationContext, "https://github.com/guhungry/react-native-photo-manipulator/blob/34c982bbba3837b32de230d2aad30aae18cf65fd/docs/demo-background.jpg?raw=true", ImageUtils.mutableOptions()
         )
-        BitmapUtils.printText(bee, "BEE\nhaha", PointF(50f, 50f), Color.BLACK, 40f, rotation = -45f)
+        val style = TextStyle(Color.BLACK, 40f, rotation = -45f)
+        BitmapUtils.printText(bee, "BEE\nhaha", PointF(50f, 50f), style)
         println(bee)
         var len = bee.height
     }

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 apply plugin: 'io.github.gradle-nexus.publish-plugin'
 
 buildscript {
-    ext.kotlin_version = '1.9.21'
+    ext.kotlin_version = '1.9.24'
     ext.mockito_version = '3.2.4'
     ext.androidJunit5Version = '1.4.2.1'
     ext.junitJupiterVersion = "5.4.2"
@@ -14,7 +14,7 @@ buildscript {
         maven { url 'https://plugins.gradle.org/m2/' }
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:8.3.2'
+        classpath 'com.android.tools.build:gradle:8.5.0'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'io.github.gradle-nexus:publish-plugin:1.1.0'
         classpath 'org.sonarsource.scanner.gradle:sonarqube-gradle-plugin:2.6.2'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/photomanipulator/src/androidTest/java/com/guhungry/photomanipulator/BitmapUtilsAndroidTest.kt
+++ b/photomanipulator/src/androidTest/java/com/guhungry/photomanipulator/BitmapUtilsAndroidTest.kt
@@ -146,11 +146,11 @@ internal class BitmapUtilsAndroidTest {
             inTargetDensity = DisplayMetrics.DENSITY_DEFAULT
             inPreferredColorSpace = ColorSpace.get(ColorSpace.Named.SRGB)
         }
-        val style = TextStyle(Color.GREEN, 23f, Typeface.DEFAULT_BOLD, shadowOffsetY = 5f, shadowOffsetX = 10f, shadowRadius = .01f, shadowColor = Color.YELLOW)
+        val style = TextStyle(Color.GREEN, 30f, Typeface.DEFAULT_BOLD, shadowOffsetY = 5f, shadowOffsetX = 10f, shadowRadius = .01f, shadowColor = Color.YELLOW)
         background = TestHelper.drawableBitmap(R.drawable.background, options)
         BitmapUtils.printText(background!!, "My Text Print", PointF(12f, 5f), style)
 
-        assertThat(background!!.getPixel(47, 18), equalTo(Color.YELLOW))
+        assertThat(background!!.getPixel(26, 5), equalTo(Color.YELLOW))
     }
 
     @Test

--- a/photomanipulator/src/androidTest/java/com/guhungry/photomanipulator/BitmapUtilsAndroidTest.kt
+++ b/photomanipulator/src/androidTest/java/com/guhungry/photomanipulator/BitmapUtilsAndroidTest.kt
@@ -4,6 +4,10 @@ import android.graphics.*
 import android.util.DisplayMetrics
 import androidx.annotation.DrawableRes
 import androidx.test.ext.junit.runners.AndroidJUnit4
+import com.guhungry.photomanipulator.model.CGRect
+import com.guhungry.photomanipulator.model.CGSize
+import com.guhungry.photomanipulator.model.FlipMode
+import com.guhungry.photomanipulator.model.RotationMode
 import com.guhungry.photomanipulator.test.R
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*

--- a/photomanipulator/src/androidTest/java/com/guhungry/photomanipulator/BitmapUtilsAndroidTest.kt
+++ b/photomanipulator/src/androidTest/java/com/guhungry/photomanipulator/BitmapUtilsAndroidTest.kt
@@ -107,7 +107,8 @@ internal class BitmapUtilsAndroidTest {
             inPreferredColorSpace = ColorSpace.get(ColorSpace.Named.SRGB)
         }
         background = TestHelper.drawableBitmap(R.drawable.background, options)
-        BitmapUtils.printText(background!!, "My Text Print", PointF(12f, 5f), Color.GREEN, 23f)
+        val style = TextStyle(Color.GREEN, 23f)
+        BitmapUtils.printText(background!!, "My Text Print", PointF(12f, 5f), style)
 
         assertThat(background!!.getPixel(14, 5), equalTo(Color.GREEN))
     }
@@ -120,7 +121,8 @@ internal class BitmapUtilsAndroidTest {
             inPreferredColorSpace = ColorSpace.get(ColorSpace.Named.SRGB)
         }
         background = TestHelper.drawableBitmap(R.drawable.background, options)
-        BitmapUtils.printText(background!!, "My Text Print", PointF(12f, 5f), Color.GREEN, 23f, Typeface.DEFAULT_BOLD, thickness = 1f)
+        val style = TextStyle(Color.GREEN, 23f, Typeface.DEFAULT_BOLD, thickness = 1f)
+        BitmapUtils.printText(background!!, "My Text Print", PointF(12f, 5f), style)
 
         assertThat(background!!.getPixel(13, 2), equalTo(Color.GREEN))
     }
@@ -133,8 +135,10 @@ internal class BitmapUtilsAndroidTest {
             inPreferredColorSpace = ColorSpace.get(ColorSpace.Named.SRGB)
         }
         background = TestHelper.drawableBitmap(R.drawable.background, options)
-        BitmapUtils.printText(background!!, "My Text\nPrint", PointF(12f, 5f), Color.GREEN, 23f, Typeface.DEFAULT_BOLD, thickness = 5f)
-        BitmapUtils.printText(background!!, "My\nText\nPrint", PointF(200f, 5f), Color.YELLOW, 23f, Typeface.DEFAULT_BOLD, thickness = 1f, alignment = Paint.Align.CENTER)
+        val style1 = TextStyle(Color.GREEN, 23f, Typeface.DEFAULT_BOLD, thickness = 5f)
+        BitmapUtils.printText(background!!, "My Text\nPrint", PointF(12f, 5f), style1)
+        val style2 = TextStyle(Color.YELLOW, 23f, Typeface.DEFAULT_BOLD, thickness = 1f, alignment = Paint.Align.CENTER)
+        BitmapUtils.printText(background!!, "My\nText\nPrint", PointF(200f, 5f), style2)
 
         assertThat(background!!.getPixel(14, 0), equalTo(Color.GREEN))
     }

--- a/photomanipulator/src/androidTest/java/com/guhungry/photomanipulator/BitmapUtilsAndroidTest.kt
+++ b/photomanipulator/src/androidTest/java/com/guhungry/photomanipulator/BitmapUtilsAndroidTest.kt
@@ -146,11 +146,11 @@ internal class BitmapUtilsAndroidTest {
             inTargetDensity = DisplayMetrics.DENSITY_DEFAULT
             inPreferredColorSpace = ColorSpace.get(ColorSpace.Named.SRGB)
         }
-        val style = TextStyle(Color.GREEN, 23f, Typeface.DEFAULT_BOLD, shadowOffsetY = 5f, shadowOffsetX = 10f, shadowRadius = 3f, shadowColor = Color.YELLOW)
+        val style = TextStyle(Color.GREEN, 23f, Typeface.DEFAULT_BOLD, shadowOffsetY = 5f, shadowOffsetX = 10f, shadowRadius = .01f, shadowColor = Color.YELLOW)
         background = TestHelper.drawableBitmap(R.drawable.background, options)
         BitmapUtils.printText(background!!, "My Text Print", PointF(12f, 5f), style)
 
-        assertThat(background!!.getPixel(13, 2), equalTo(Color.GREEN))
+        assertThat(background!!.getPixel(47, 18), equalTo(Color.YELLOW))
     }
 
     @Test

--- a/photomanipulator/src/androidTest/java/com/guhungry/photomanipulator/BitmapUtilsAndroidTest.kt
+++ b/photomanipulator/src/androidTest/java/com/guhungry/photomanipulator/BitmapUtilsAndroidTest.kt
@@ -8,6 +8,7 @@ import com.guhungry.photomanipulator.model.CGRect
 import com.guhungry.photomanipulator.model.CGSize
 import com.guhungry.photomanipulator.model.FlipMode
 import com.guhungry.photomanipulator.model.RotationMode
+import com.guhungry.photomanipulator.model.TextStyle
 import com.guhungry.photomanipulator.test.R
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.*
@@ -136,6 +137,20 @@ internal class BitmapUtilsAndroidTest {
         BitmapUtils.printText(background!!, "My\nText\nPrint", PointF(200f, 5f), Color.YELLOW, 23f, Typeface.DEFAULT_BOLD, thickness = 1f, alignment = Paint.Align.CENTER)
 
         assertThat(background!!.getPixel(14, 0), equalTo(Color.GREEN))
+    }
+
+    @Test
+    fun printText_when_all_shadow_should_text_correctly() {
+        val options = BitmapFactory.Options().apply {
+            inMutable = true
+            inTargetDensity = DisplayMetrics.DENSITY_DEFAULT
+            inPreferredColorSpace = ColorSpace.get(ColorSpace.Named.SRGB)
+        }
+        val style = TextStyle(Color.GREEN, 23f, Typeface.DEFAULT_BOLD, shadowOffsetY = 5f, shadowOffsetX = 10f, shadowRadius = 3f, shadowColor = Color.YELLOW)
+        background = TestHelper.drawableBitmap(R.drawable.background, options)
+        BitmapUtils.printText(background!!, "My Text Print", PointF(12f, 5f), style)
+
+        assertThat(background!!.getPixel(13, 2), equalTo(Color.GREEN))
     }
 
     @Test

--- a/photomanipulator/src/main/java/com/guhungry/photomanipulator/BitmapUtils.kt
+++ b/photomanipulator/src/main/java/com/guhungry/photomanipulator/BitmapUtils.kt
@@ -189,10 +189,7 @@ object BitmapUtils {
                 typeface = it
             }
 
-            if (textStyle.thickness > 0) {
-                style = Paint.Style.STROKE
-                strokeWidth = textStyle.thickness
-            }
+            setTextBorder(textStyle)
         }
 
         var offset = position.y + (textStyle.size / 2)
@@ -205,6 +202,12 @@ object BitmapUtils {
             offset += paint.descent() - paint.ascent()
         }
         canvas.restore()
+    }
+
+    private fun Paint.setTextBorder(textStyle: TextStyle) {
+        if (textStyle.thickness <= 0) return
+        style = Paint.Style.STROKE
+        strokeWidth = textStyle.thickness
     }
 
     /**

--- a/photomanipulator/src/main/java/com/guhungry/photomanipulator/BitmapUtils.kt
+++ b/photomanipulator/src/main/java/com/guhungry/photomanipulator/BitmapUtils.kt
@@ -9,6 +9,7 @@ import com.guhungry.photomanipulator.model.CGRect
 import com.guhungry.photomanipulator.model.CGSize
 import com.guhungry.photomanipulator.model.FlipMode
 import com.guhungry.photomanipulator.model.RotationMode
+import com.guhungry.photomanipulator.model.TextStyle
 import java.io.IOException
 import java.io.InputStream
 import kotlin.math.floor
@@ -157,28 +158,46 @@ object BitmapUtils {
      */
     @JvmStatic
     @JvmOverloads
+    @Deprecated("Use printText(Bitmap, String, PointF, TextStyle, AndroidFactory) instead")
     fun printText(image: Bitmap, text: String, position: PointF, color: Int, size: Float, font: Typeface? = null, alignment: Paint.Align = Paint.Align.LEFT, thickness: Float = 0f, rotation: Float? = null, factory: AndroidFactory = AndroidConcreteFactory()) {
+        val style = TextStyle(color, size, font, alignment, thickness, rotation)
+        return printText(image, text, position, style, factory)
+    }
+
+    /**
+     * Print text in to image
+     *
+     * @param image Source image
+     * @param text Text to be printed
+     * @param position Position of text in image
+     * @param textStyle Text style
+     * @param factory (Optional) Factory for creating Android Objects for Testing
+     */
+    @JvmStatic
+    @JvmOverloads
+    fun printText(image: Bitmap, text: String, position: PointF, textStyle: TextStyle, factory: AndroidFactory = AndroidConcreteFactory()) {
         val canvas = factory.makeCanvas(image)
 
         val paint = factory.makePaint().apply {
-            this.color = color
-            textSize = size
-            textAlign = alignment
+            color = textStyle.color
+            textSize = textStyle.size
+            textAlign = textStyle.alignment
+            isAntiAlias = true
 
-            if (font != null) {
-                typeface = font
+            textStyle.font?.let {
+                typeface = it
             }
 
-            if (thickness > 0) {
+            if (textStyle.thickness > 0) {
                 style = Paint.Style.STROKE
-                strokeWidth = thickness
+                strokeWidth = textStyle.thickness
             }
         }
 
-        var offset = position.y + (size / 2)
+        var offset = position.y + (textStyle.size / 2)
         // Rotate
         canvas.save()
-        canvas.rotate(-(rotation ?: 0f), position.x, offset)
+        canvas.rotate(-(textStyle.rotation ?: 0f), position.x, offset)
         // Draw Text
         text.split("\n").forEach {
             canvas.drawText(it, position.x, offset, paint)

--- a/photomanipulator/src/main/java/com/guhungry/photomanipulator/BitmapUtils.kt
+++ b/photomanipulator/src/main/java/com/guhungry/photomanipulator/BitmapUtils.kt
@@ -5,6 +5,10 @@ import android.os.Build
 import androidx.exifinterface.media.ExifInterface
 import com.guhungry.photomanipulator.factory.AndroidFactory
 import com.guhungry.photomanipulator.factory.AndroidConcreteFactory
+import com.guhungry.photomanipulator.model.CGRect
+import com.guhungry.photomanipulator.model.CGSize
+import com.guhungry.photomanipulator.model.FlipMode
+import com.guhungry.photomanipulator.model.RotationMode
 import java.io.IOException
 import java.io.InputStream
 import kotlin.math.floor

--- a/photomanipulator/src/main/java/com/guhungry/photomanipulator/BitmapUtils.kt
+++ b/photomanipulator/src/main/java/com/guhungry/photomanipulator/BitmapUtils.kt
@@ -190,6 +190,7 @@ object BitmapUtils {
             }
 
             setTextBorder(textStyle)
+            setTextShadow(textStyle)
         }
 
         var offset = position.y + (textStyle.size / 2)
@@ -208,6 +209,16 @@ object BitmapUtils {
         if (textStyle.thickness <= 0) return
         style = Paint.Style.STROKE
         strokeWidth = textStyle.thickness
+    }
+
+    private fun Paint.setTextShadow(textStyle: TextStyle) {
+        if (textStyle.shadowColor == null) return
+        setShadowLayer(
+            textStyle.shadowRadius,
+            textStyle.shadowOffsetX,
+            textStyle.shadowOffsetY,
+            textStyle.shadowColor
+        )
     }
 
     /**

--- a/photomanipulator/src/main/java/com/guhungry/photomanipulator/BitmapUtils.kt
+++ b/photomanipulator/src/main/java/com/guhungry/photomanipulator/BitmapUtils.kt
@@ -212,7 +212,7 @@ object BitmapUtils {
     }
 
     private fun Paint.setTextShadow(textStyle: TextStyle) {
-        if (textStyle.shadowColor == null) return
+        if (textStyle.shadowColor == null || textStyle.shadowRadius <= 0f) return
         setShadowLayer(
             textStyle.shadowRadius,
             textStyle.shadowOffsetX,

--- a/photomanipulator/src/main/java/com/guhungry/photomanipulator/BitmapUtils.kt
+++ b/photomanipulator/src/main/java/com/guhungry/photomanipulator/BitmapUtils.kt
@@ -176,8 +176,9 @@ object BitmapUtils {
     @JvmStatic
     @JvmOverloads
     fun printText(image: Bitmap, text: String, position: PointF, textStyle: TextStyle, factory: AndroidFactory = AndroidConcreteFactory()) {
-        val canvas = factory.makeCanvas(image)
+        if (text.isBlank()) return
 
+        val canvas = factory.makeCanvas(image)
         val paint = factory.makePaint().apply {
             color = textStyle.color
             textSize = textStyle.size

--- a/photomanipulator/src/main/java/com/guhungry/photomanipulator/model/CGRect.kt
+++ b/photomanipulator/src/main/java/com/guhungry/photomanipulator/model/CGRect.kt
@@ -1,4 +1,4 @@
-package com.guhungry.photomanipulator
+package com.guhungry.photomanipulator.model
 
 import android.graphics.Point
 import android.graphics.Rect

--- a/photomanipulator/src/main/java/com/guhungry/photomanipulator/model/FlipMode.kt
+++ b/photomanipulator/src/main/java/com/guhungry/photomanipulator/model/FlipMode.kt
@@ -1,4 +1,4 @@
-package com.guhungry.photomanipulator
+package com.guhungry.photomanipulator.model
 
 enum class FlipMode(val scaleX: Float, val scaleY: Float) {
     Both(-1f, -1f),

--- a/photomanipulator/src/main/java/com/guhungry/photomanipulator/model/RotationMode.kt
+++ b/photomanipulator/src/main/java/com/guhungry/photomanipulator/model/RotationMode.kt
@@ -1,4 +1,4 @@
-package com.guhungry.photomanipulator
+package com.guhungry.photomanipulator.model
 
 enum class RotationMode(val degrees: Float) {
     None(0f),

--- a/photomanipulator/src/main/java/com/guhungry/photomanipulator/model/TextStyle.kt
+++ b/photomanipulator/src/main/java/com/guhungry/photomanipulator/model/TextStyle.kt
@@ -12,7 +12,7 @@ import android.graphics.Typeface
  * @property alignment Optional text alignment. Defaults to[Paint.Align.LEFT].
  * @property thickness Optional border thickness. Defaults to 0f (no border).
  * @property rotation Optional rotation of the text in degrees. Defaults to null (no rotation).
- * @property shadowRadius Optional shadow radius. Defaults to 0f (no shadow radius).
+ * @property shadowRadius Optional shadow radius. Defaults to 0f (no shadow).
  * @property shadowOffsetX Optional shadow offset X. Defaults to 0f (no shadow offset x axis).
  * @property shadowOffsetY Optional shadow offset Y. Defaults to 0f (no shadow offset y axis).
  * @property shadowColor Optional shadow color. Defaults to null (no shadow color).

--- a/photomanipulator/src/main/java/com/guhungry/photomanipulator/model/TextStyle.kt
+++ b/photomanipulator/src/main/java/com/guhungry/photomanipulator/model/TextStyle.kt
@@ -1,0 +1,24 @@
+package com.guhungry.photomanipulator.model
+
+import android.graphics.Paint
+import android.graphics.Typeface
+
+/**
+ * Defines the style for text drawn on a Bitmap.
+ *
+ * @property color Color of the text.
+ * @property size Size of the text.
+ * @property font Optional font for the text. Defaults to null (system default).
+ * @property alignment Optional text alignment. Defaults to[Paint.Align.LEFT].
+ * @property thickness Optional border thickness. Defaults to 0f (no border).
+ * @property rotation Optional rotation of the text in degrees. Defaults to null (no rotation).
+ * @see com.guhungry.photomanipulator.BitmapUtils#printText(Bitmap, String, PointF, TextStyle, AndroidFactory)
+ */
+data class TextStyle(
+    val color: Int,
+    val size: Float,
+    val font: Typeface? = null,
+    val alignment: Paint.Align = Paint.Align.LEFT,
+    val thickness: Float = 0f,
+    val rotation: Float? = null
+)

--- a/photomanipulator/src/main/java/com/guhungry/photomanipulator/model/TextStyle.kt
+++ b/photomanipulator/src/main/java/com/guhungry/photomanipulator/model/TextStyle.kt
@@ -12,6 +12,10 @@ import android.graphics.Typeface
  * @property alignment Optional text alignment. Defaults to[Paint.Align.LEFT].
  * @property thickness Optional border thickness. Defaults to 0f (no border).
  * @property rotation Optional rotation of the text in degrees. Defaults to null (no rotation).
+ * @property shadowRadius Optional shadow radius. Defaults to 0f (no shadow radius).
+ * @property shadowOffsetX Optional shadow offset X. Defaults to 0f (no shadow offset x axis).
+ * @property shadowOffsetY Optional shadow offset Y. Defaults to 0f (no shadow offset y axis).
+ * @property shadowColor Optional shadow color. Defaults to null (no shadow color).
  * @see com.guhungry.photomanipulator.BitmapUtils#printText(Bitmap, String, PointF, TextStyle, AndroidFactory)
  */
 data class TextStyle(
@@ -20,5 +24,9 @@ data class TextStyle(
     val font: Typeface? = null,
     val alignment: Paint.Align = Paint.Align.LEFT,
     val thickness: Float = 0f,
-    val rotation: Float? = null
+    val rotation: Float? = null,
+    val shadowRadius: Float = 0f,
+    val shadowOffsetX: Float = 0f,
+    val shadowOffsetY: Float = 0f,
+    val shadowColor: Int? = null
 )

--- a/photomanipulator/src/test/java/com/guhungry/photomanipulator/BitmapUtilsTest.kt
+++ b/photomanipulator/src/test/java/com/guhungry/photomanipulator/BitmapUtilsTest.kt
@@ -3,6 +3,7 @@ package com.guhungry.photomanipulator
 import android.graphics.*
 import com.guhungry.photomanipulator.factory.AndroidFactory
 import com.guhungry.photomanipulator.factory.MockAndroidFactory
+import com.guhungry.photomanipulator.factory.TestHelpers.mockPointF
 import com.guhungry.photomanipulator.model.CGRect
 import com.guhungry.photomanipulator.model.CGSize
 import com.guhungry.photomanipulator.model.FlipMode
@@ -19,7 +20,7 @@ internal class BitmapUtilsTest {
     fun `printText should skip process when text is empty or blank`() {
         val style = TextStyle(555, 45f)
         val background = mock(Bitmap::class.java)
-        val location = PointF(99f, 74f)
+        val location = mockPointF(99f, 74f)
         val factory = mock(AndroidFactory::class.java)
 
         BitmapUtils.printText(background, "", location, style, factory)
@@ -33,7 +34,7 @@ internal class BitmapUtilsTest {
     fun `printText should skip setTextBorder when text thickness equal 0`() {
         val style = TextStyle(555, 45f, thickness = 0f)
         val background = mock(Bitmap::class.java)
-        val location = PointF(99f, 74f)
+        val location = mockPointF(99f, 74f)
         val canvas = mock(Canvas::class.java)
         val paint = mock(Paint::class.java)
         val factory = mock(AndroidFactory::class.java)
@@ -49,7 +50,7 @@ internal class BitmapUtilsTest {
     fun `printText should skip setTextBorder when text thickness less than  0`() {
         val style = TextStyle(555, 45f, thickness = -100f)
         val background = mock(Bitmap::class.java)
-        val location = PointF(99f, 74f)
+        val location = mockPointF(99f, 74f)
         val canvas = mock(Canvas::class.java)
         val paint = mock(Paint::class.java)
         val factory = mock(AndroidFactory::class.java)
@@ -64,10 +65,7 @@ internal class BitmapUtilsTest {
     @Test
     fun `printText should draw correctly without alignment use default AlignLEFT`() {
         val background = mock(Bitmap::class.java)
-        val location = PointF().apply {
-            x = 99f
-            y = 74f
-        }
+        val location = mockPointF(99f, 74f)
         val canvas = mock(Canvas::class.java)
         val paint = mock(Paint::class.java)
         val factory = mock(AndroidFactory::class.java)
@@ -89,10 +87,7 @@ internal class BitmapUtilsTest {
     @Test
     fun `printText should draw correctly without thickness use default thickness 0`() {
         val background = mock(Bitmap::class.java)
-        val location = PointF().apply {
-            x = 99f
-            y = 74f
-        }
+        val location = mockPointF(99f, 74f)
         val canvas = mock(Canvas::class.java)
         val paint = mock(Paint::class.java)
         val factory = mock(AndroidFactory::class.java)
@@ -114,10 +109,7 @@ internal class BitmapUtilsTest {
     @Test
     fun `printText should draw correctly without font use default font`() {
         val background = mock(Bitmap::class.java)
-        val location = PointF().apply {
-            x = 99f
-            y = 74f
-        }
+        val location = mockPointF(99f, 74f)
         val canvas = mock(Canvas::class.java)
         val paint = mock(Paint::class.java)
         val factory = mock(AndroidFactory::class.java)
@@ -148,10 +140,7 @@ internal class BitmapUtilsTest {
     @Test
     fun `printText should draw correctly with all values`() {
         val background = mock(Bitmap::class.java)
-        val location = PointF().apply {
-            x = 23f
-            y = 14f
-        }
+        val location = mockPointF(23f, 14f)
         val canvas = mock(Canvas::class.java)
         val paint = mock(Paint::class.java)
         val factory = mock(AndroidFactory::class.java)
@@ -174,10 +163,7 @@ internal class BitmapUtilsTest {
     @Test
     fun `printText when rotation null should rotate with 0`() {
         val background = mock(Bitmap::class.java)
-        val location = PointF().apply {
-            x = 69f
-            y = 55f
-        }
+        val location = mockPointF(69f, 55f)
         val canvas = mock(Canvas::class.java)
         val paint = mock(Paint::class.java)
         val factory = mock(AndroidFactory::class.java)
@@ -199,10 +185,7 @@ internal class BitmapUtilsTest {
     fun `overlay should draw image correctly`() {
         val background = mock(Bitmap::class.java)
         val overlay = mock(Bitmap::class.java)
-        val location = PointF().apply {
-            x = 75f
-            y = 95f
-        }
+        val location = mockPointF(75f, 95f)
         val canvas = mock(Canvas::class.java)
         val paint = mock(Paint::class.java)
         val factory = mock(AndroidFactory::class.java)

--- a/photomanipulator/src/test/java/com/guhungry/photomanipulator/BitmapUtilsTest.kt
+++ b/photomanipulator/src/test/java/com/guhungry/photomanipulator/BitmapUtilsTest.kt
@@ -156,14 +156,8 @@ internal class BitmapUtilsTest {
         `when`(factory.makeCanvas(background)).thenReturn(canvas)
         `when`(factory.makePaint()).thenReturn(paint)
 
-        BitmapUtils.printText(
-            background,
-            "Text no alignment",
-            location,
-            555,
-            45f,
-            factory = factory
-        )
+        val style = TextStyle(555, 45f)
+        BitmapUtils.printText(background, "Text no alignment", location, style, factory)
 
         verify(paint, times(1)).textAlign = Paint.Align.LEFT
     }
@@ -178,14 +172,8 @@ internal class BitmapUtilsTest {
         `when`(factory.makeCanvas(background)).thenReturn(canvas)
         `when`(factory.makePaint()).thenReturn(paint)
 
-        BitmapUtils.printText(
-            background,
-            "Text no Thickness",
-            location,
-            555,
-            45f,
-            factory = factory
-        )
+        val style = TextStyle(555, 45f)
+        BitmapUtils.printText(background, "Text no Thickness", location, style, factory)
 
         assertNoTextBorder(paint)
     }
@@ -200,14 +188,8 @@ internal class BitmapUtilsTest {
         `when`(factory.makeCanvas(background)).thenReturn(canvas)
         `when`(factory.makePaint()).thenReturn(paint)
 
-        BitmapUtils.printText(
-            background,
-            "Text no Thickness",
-            location,
-            555,
-            45f,
-            factory = factory
-        )
+        val style = TextStyle(555, 45f)
+        BitmapUtils.printText(background, "Text no Thickness", location, style, factory)
 
         assertNoFont(paint)
     }
@@ -232,7 +214,8 @@ internal class BitmapUtilsTest {
         `when`(factory.makeCanvas(background)).thenReturn(canvas)
         `when`(factory.makePaint()).thenReturn(paint)
 
-        BitmapUtils.printText(background, "Text all Values", location, 432, 74f, font, Paint.Align.CENTER, 4f, 45f, factory)
+        val style = TextStyle(432, 74f, font, Paint.Align.CENTER, 4f, 45f)
+        BitmapUtils.printText(background, "Text all Values", location, style, factory)
 
         verify(paint, times(1)).color = 432
         verify(paint, times(1)).textSize = 74f
@@ -255,7 +238,8 @@ internal class BitmapUtilsTest {
         `when`(factory.makeCanvas(background)).thenReturn(canvas)
         `when`(factory.makePaint()).thenReturn(paint)
 
-        BitmapUtils.printText(background, "rotation null", location, 772, 84f, font, Paint.Align.RIGHT, 0f, null, factory)
+        val style = TextStyle(772, 84f, font, Paint.Align.RIGHT, 0f, null)
+        BitmapUtils.printText(background, "rotation null", location, style, factory)
 
         verify(paint, times(1)).color = 772
         verify(paint, times(1)).textSize = 84f

--- a/photomanipulator/src/test/java/com/guhungry/photomanipulator/BitmapUtilsTest.kt
+++ b/photomanipulator/src/test/java/com/guhungry/photomanipulator/BitmapUtilsTest.kt
@@ -17,6 +17,58 @@ import org.mockito.Mockito.*
 
 internal class BitmapUtilsTest {
     @Test
+    fun `printText should skip shadow when shadow color is null`() {
+        val style = TextStyle(555, 45f)
+        val background = mock(Bitmap::class.java)
+        val location = mockPointF(99f, 74f)
+        val canvas = mock(Canvas::class.java)
+        val paint = mock(Paint::class.java)
+        val factory = mock(AndroidFactory::class.java)
+        `when`(factory.makeCanvas(background)).thenReturn(canvas)
+        `when`(factory.makePaint()).thenReturn(paint)
+
+        BitmapUtils.printText(background, "shadowColor = null", location, style, factory)
+
+        assertNoTextShadow(paint)
+    }
+
+    @Test
+    fun `printText should set shadow when shadow color 888`() {
+        val style = TextStyle(555, 45f, shadowColor = 888)
+        val background = mock(Bitmap::class.java)
+        val location = mockPointF(99f, 74f)
+        val canvas = mock(Canvas::class.java)
+        val paint = mock(Paint::class.java)
+        val factory = mock(AndroidFactory::class.java)
+        `when`(factory.makeCanvas(background)).thenReturn(canvas)
+        `when`(factory.makePaint()).thenReturn(paint)
+
+        BitmapUtils.printText(background, "shadowColor = null", location, style, factory)
+
+        verify(paint, times(1)).setShadowLayer(0f, 0f, 0f, 888)
+    }
+
+    @Test
+    fun `printText should set shadow when all shadow values`() {
+        val style = TextStyle(555, 45f, shadowRadius = 1f, shadowOffsetX = 2f, shadowOffsetY = 3f, shadowColor = 123)
+        val background = mock(Bitmap::class.java)
+        val location = mockPointF(99f, 74f)
+        val canvas = mock(Canvas::class.java)
+        val paint = mock(Paint::class.java)
+        val factory = mock(AndroidFactory::class.java)
+        `when`(factory.makeCanvas(background)).thenReturn(canvas)
+        `when`(factory.makePaint()).thenReturn(paint)
+
+        BitmapUtils.printText(background, "shadowColor = null", location, style, factory)
+
+        verify(paint, times(1)).setShadowLayer(1f, 2f, 3f, 123)
+    }
+
+    private fun assertNoTextShadow(paint: Paint) {
+        verify(paint, never()).setShadowLayer(anyFloat(), anyFloat(), anyFloat(), anyInt())
+    }
+
+    @Test
     fun `printText should skip process when text is empty or blank`() {
         val style = TextStyle(555, 45f)
         val background = mock(Bitmap::class.java)

--- a/photomanipulator/src/test/java/com/guhungry/photomanipulator/BitmapUtilsTest.kt
+++ b/photomanipulator/src/test/java/com/guhungry/photomanipulator/BitmapUtilsTest.kt
@@ -30,7 +30,32 @@ internal class BitmapUtilsTest {
     }
 
     @Test
-    fun `printText should draw correctly without alignment and thickness`() {
+    fun `printText should draw correctly without alignment use default AlignLEFT`() {
+        val background = mock(Bitmap::class.java)
+        val location = PointF().apply {
+            x = 99f
+            y = 74f
+        }
+        val canvas = mock(Canvas::class.java)
+        val paint = mock(Paint::class.java)
+        val factory = mock(AndroidFactory::class.java)
+        `when`(factory.makeCanvas(background)).thenReturn(canvas)
+        `when`(factory.makePaint()).thenReturn(paint)
+
+        BitmapUtils.printText(
+            background,
+            "Text no alignment",
+            location,
+            555,
+            45f,
+            factory = factory
+        )
+
+        verify(paint, times(1)).textAlign = Paint.Align.LEFT
+    }
+
+    @Test
+    fun `printText should draw correctly without thickness use default thickness 0`() {
         val background = mock(Bitmap::class.java)
         val location = PointF().apply {
             x = 99f
@@ -51,12 +76,40 @@ internal class BitmapUtilsTest {
             factory = factory
         )
 
-        verify(paint, times(1)).color = 555
-        verify(paint, times(1)).textSize = 45f
-        verify(paint, times(1)).textAlign = Paint.Align.LEFT
-        verify(canvas, times(1)).drawText("Text no Thickness", 99f, 96.5f, paint)
+        assertNoTextBorder(paint)
+    }
+
+    @Test
+    fun `printText should draw correctly without font use default font`() {
+        val background = mock(Bitmap::class.java)
+        val location = PointF().apply {
+            x = 99f
+            y = 74f
+        }
+        val canvas = mock(Canvas::class.java)
+        val paint = mock(Paint::class.java)
+        val factory = mock(AndroidFactory::class.java)
+        `when`(factory.makeCanvas(background)).thenReturn(canvas)
+        `when`(factory.makePaint()).thenReturn(paint)
+
+        BitmapUtils.printText(
+            background,
+            "Text no Thickness",
+            location,
+            555,
+            45f,
+            factory = factory
+        )
+
+        assertNoFont(paint)
+    }
+
+    private fun assertNoFont(paint: Paint) {
+        verify(paint, never()).typeface = any()
+    }
+
+    private fun assertNoTextBorder(paint: Paint) {
         verify(paint, never()).strokeWidth = anyFloat()
-        verify(paint, never()).setTypeface(any())
         verify(paint, never()).style = any()
     }
 
@@ -80,7 +133,7 @@ internal class BitmapUtilsTest {
         verify(paint, times(1)).textSize = 74f
         verify(paint, times(1)).textAlign = Paint.Align.CENTER
         verify(paint, times(1)).style = Paint.Style.STROKE
-        verify(paint, times(1)).setTypeface(font)
+        verify(paint, times(1)).typeface = font
         verify(paint, times(1)).strokeWidth = 4f
         verify(canvas, times(1)).drawText("Text all Values", 23f, 51f, paint)
         verify(canvas, times(1)).rotate(-45f, 23f, 51f)
@@ -102,10 +155,10 @@ internal class BitmapUtilsTest {
 
         BitmapUtils.printText(background, "rotation null", location, 772, 84f, font, Paint.Align.RIGHT, 0f, null, factory)
 
-        verify(paint, times(1)).setColor(772)
+        verify(paint, times(1)).color = 772
         verify(paint, times(1)).textSize = 84f
         verify(paint, times(1)).textAlign = Paint.Align.RIGHT
-        verify(paint, times(1)).setTypeface(font)
+        verify(paint, times(1)).typeface = font
         verify(canvas, times(1)).drawText("rotation null", 69f, 97f, paint)
         verify(canvas, times(1)).rotate(-0f, 69f, 97f)
     }
@@ -126,7 +179,7 @@ internal class BitmapUtilsTest {
 
         BitmapUtils.overlay(background, overlay, location, factory)
 
-        verify(paint, times(1)).setXfermode(any<PorterDuffXfermode>())
+        verify(paint, times(1)).xfermode = any<PorterDuffXfermode>()
         verify(canvas, times(1)).drawBitmap(overlay, 75f, 95f, paint)
     }
 

--- a/photomanipulator/src/test/java/com/guhungry/photomanipulator/BitmapUtilsTest.kt
+++ b/photomanipulator/src/test/java/com/guhungry/photomanipulator/BitmapUtilsTest.kt
@@ -7,6 +7,7 @@ import com.guhungry.photomanipulator.model.CGRect
 import com.guhungry.photomanipulator.model.CGSize
 import com.guhungry.photomanipulator.model.FlipMode
 import com.guhungry.photomanipulator.model.RotationMode
+import com.guhungry.photomanipulator.model.TextStyle
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.sameInstance
 import org.hamcrest.MatcherAssert.assertThat
@@ -14,6 +15,20 @@ import org.junit.Test
 import org.mockito.Mockito.*
 
 internal class BitmapUtilsTest {
+    @Test
+    fun `printText should skip process when text is empty or blank`() {
+        val style = TextStyle(555, 45f)
+        val background = mock(Bitmap::class.java)
+        val location = PointF(99f, 74f)
+        val factory = mock(AndroidFactory::class.java)
+
+        BitmapUtils.printText(background, "", location, style, factory)
+        BitmapUtils.printText(background, "     ", location, style, factory)
+
+        verify(factory, never()).makeCanvas(background)
+        verify(factory, never()).makePaint()
+    }
+
     @Test
     fun `printText should draw correctly without alignment and thickness`() {
         val background = mock(Bitmap::class.java)
@@ -27,7 +42,14 @@ internal class BitmapUtilsTest {
         `when`(factory.makeCanvas(background)).thenReturn(canvas)
         `when`(factory.makePaint()).thenReturn(paint)
 
-        BitmapUtils.printText(background, "Text no Thickness", location, 555, 45f, factory = factory)
+        BitmapUtils.printText(
+            background,
+            "Text no Thickness",
+            location,
+            555,
+            45f,
+            factory = factory
+        )
 
         verify(paint, times(1)).color = 555
         verify(paint, times(1)).textSize = 45f

--- a/photomanipulator/src/test/java/com/guhungry/photomanipulator/BitmapUtilsTest.kt
+++ b/photomanipulator/src/test/java/com/guhungry/photomanipulator/BitmapUtilsTest.kt
@@ -18,7 +18,39 @@ import org.mockito.Mockito.*
 internal class BitmapUtilsTest {
     @Test
     fun `printText should skip shadow when shadow color is null`() {
-        val style = TextStyle(555, 45f)
+        val style = TextStyle(555, 45f, shadowRadius = 1f)
+        val background = mock(Bitmap::class.java)
+        val location = mockPointF(99f, 74f)
+        val canvas = mock(Canvas::class.java)
+        val paint = mock(Paint::class.java)
+        val factory = mock(AndroidFactory::class.java)
+        `when`(factory.makeCanvas(background)).thenReturn(canvas)
+        `when`(factory.makePaint()).thenReturn(paint)
+
+        BitmapUtils.printText(background, "shadowColor = null", location, style, factory)
+
+        assertNoTextShadow(paint)
+    }
+
+    @Test
+    fun `printText should skip shadow when shadow radius equal 0`() {
+        val style = TextStyle(555, 45f, shadowColor = 888, shadowRadius = 0f)
+        val background = mock(Bitmap::class.java)
+        val location = mockPointF(99f, 74f)
+        val canvas = mock(Canvas::class.java)
+        val paint = mock(Paint::class.java)
+        val factory = mock(AndroidFactory::class.java)
+        `when`(factory.makeCanvas(background)).thenReturn(canvas)
+        `when`(factory.makePaint()).thenReturn(paint)
+
+        BitmapUtils.printText(background, "shadowColor = null", location, style, factory)
+
+        assertNoTextShadow(paint)
+    }
+
+    @Test
+    fun `printText should skip shadow when shadow radius less than 0`() {
+        val style = TextStyle(555, 45f, shadowColor = 888, shadowRadius = -1f)
         val background = mock(Bitmap::class.java)
         val location = mockPointF(99f, 74f)
         val canvas = mock(Canvas::class.java)
@@ -34,7 +66,7 @@ internal class BitmapUtilsTest {
 
     @Test
     fun `printText should set shadow when shadow color 888`() {
-        val style = TextStyle(555, 45f, shadowColor = 888)
+        val style = TextStyle(555, 45f, shadowColor = 888, shadowRadius = 4f)
         val background = mock(Bitmap::class.java)
         val location = mockPointF(99f, 74f)
         val canvas = mock(Canvas::class.java)
@@ -45,7 +77,7 @@ internal class BitmapUtilsTest {
 
         BitmapUtils.printText(background, "shadowColor = null", location, style, factory)
 
-        verify(paint, times(1)).setShadowLayer(0f, 0f, 0f, 888)
+        verify(paint, times(1)).setShadowLayer(4f, 0f, 0f, 888)
     }
 
     @Test

--- a/photomanipulator/src/test/java/com/guhungry/photomanipulator/BitmapUtilsTest.kt
+++ b/photomanipulator/src/test/java/com/guhungry/photomanipulator/BitmapUtilsTest.kt
@@ -30,6 +30,38 @@ internal class BitmapUtilsTest {
     }
 
     @Test
+    fun `printText should skip setTextBorder when text thickness equal 0`() {
+        val style = TextStyle(555, 45f, thickness = 0f)
+        val background = mock(Bitmap::class.java)
+        val location = PointF(99f, 74f)
+        val canvas = mock(Canvas::class.java)
+        val paint = mock(Paint::class.java)
+        val factory = mock(AndroidFactory::class.java)
+        `when`(factory.makeCanvas(background)).thenReturn(canvas)
+        `when`(factory.makePaint()).thenReturn(paint)
+
+        BitmapUtils.printText(background, "border = 0", location, style, factory)
+
+        assertNoTextBorder(paint)
+    }
+
+    @Test
+    fun `printText should skip setTextBorder when text thickness less than  0`() {
+        val style = TextStyle(555, 45f, thickness = -100f)
+        val background = mock(Bitmap::class.java)
+        val location = PointF(99f, 74f)
+        val canvas = mock(Canvas::class.java)
+        val paint = mock(Paint::class.java)
+        val factory = mock(AndroidFactory::class.java)
+        `when`(factory.makeCanvas(background)).thenReturn(canvas)
+        `when`(factory.makePaint()).thenReturn(paint)
+
+        BitmapUtils.printText(background, "border < 0", location, style, factory)
+
+        assertNoTextBorder(paint)
+    }
+
+    @Test
     fun `printText should draw correctly without alignment use default AlignLEFT`() {
         val background = mock(Bitmap::class.java)
         val location = PointF().apply {

--- a/photomanipulator/src/test/java/com/guhungry/photomanipulator/BitmapUtilsTest.kt
+++ b/photomanipulator/src/test/java/com/guhungry/photomanipulator/BitmapUtilsTest.kt
@@ -3,6 +3,10 @@ package com.guhungry.photomanipulator
 import android.graphics.*
 import com.guhungry.photomanipulator.factory.AndroidFactory
 import com.guhungry.photomanipulator.factory.MockAndroidFactory
+import com.guhungry.photomanipulator.model.CGRect
+import com.guhungry.photomanipulator.model.CGSize
+import com.guhungry.photomanipulator.model.FlipMode
+import com.guhungry.photomanipulator.model.RotationMode
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.CoreMatchers.sameInstance
 import org.hamcrest.MatcherAssert.assertThat

--- a/photomanipulator/src/test/java/com/guhungry/photomanipulator/CGRectTest.kt
+++ b/photomanipulator/src/test/java/com/guhungry/photomanipulator/CGRectTest.kt
@@ -4,6 +4,8 @@ import android.graphics.Point
 import android.graphics.Rect
 import com.guhungry.photomanipulator.factory.AndroidFactory
 import com.guhungry.photomanipulator.factory.MockAndroidFactory
+import com.guhungry.photomanipulator.model.CGRect
+import com.guhungry.photomanipulator.model.CGSize
 import org.hamcrest.CoreMatchers.*
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.After

--- a/photomanipulator/src/test/java/com/guhungry/photomanipulator/CGSizeTest.kt
+++ b/photomanipulator/src/test/java/com/guhungry/photomanipulator/CGSizeTest.kt
@@ -1,5 +1,6 @@
 package com.guhungry.photomanipulator
 
+import com.guhungry.photomanipulator.model.CGSize
 import org.hamcrest.CoreMatchers.equalTo
 import org.hamcrest.MatcherAssert.assertThat
 import org.junit.After

--- a/photomanipulator/src/test/java/com/guhungry/photomanipulator/factory/TestHelpers.kt
+++ b/photomanipulator/src/test/java/com/guhungry/photomanipulator/factory/TestHelpers.kt
@@ -1,0 +1,13 @@
+package com.guhungry.photomanipulator.factory
+
+import android.graphics.PointF
+import org.mockito.Mockito.mock
+
+object TestHelpers {
+    internal fun mockPointF(x: Float, y: Float): PointF {
+        return mock(PointF::class.java).apply {
+            this.x = x
+            this.y = y
+        }
+    }
+}


### PR DESCRIPTION
Add support for shadow for text style in printText()

![shadow5451711621155079143](https://github.com/guhungry/android-photo-manipulator/assets/4032276/f923be2d-2c5f-4b70-b4d5-187836dd6263)
